### PR TITLE
Break apart NetworkRequest template types

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024 Justin Williams
+Copyright (c) 2025 Justin Williams
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -4,4 +4,4 @@ A set of networking helpers and types I use in my various projects.
 
 ## License
 
-Copyright 2024 Justin Williams. Licensed under the MIT license.
+Copyright 2025 Justin Williams. Licensed under the MIT license.

--- a/Sources/JWWNetworking/HTTPClient.swift
+++ b/Sources/JWWNetworking/HTTPClient.swift
@@ -73,7 +73,7 @@ public actor HTTPClient {
 
     /// Convert a request template into a network request and attempt to return the expected values.
     @discardableResult
-    public func send<T: NetworkRequest>(template: T) async throws(JWWNetworkError) -> T.Output {
+    public func send<T: NetworkRequestTemplate>(template: T) async throws(JWWNetworkError) -> T.Output {
         let builder = NetworkRequestBuilder(template: template)
         var generatedRequest = try await builder.build(for: self)
 

--- a/Sources/JWWNetworking/JWWNetworkError.swift
+++ b/Sources/JWWNetworking/JWWNetworkError.swift
@@ -14,6 +14,11 @@ public enum JWWNetworkError: Error, CustomNSError, CustomStringConvertible {
     /// A request couldn't be generated because the URL was invalid.
     case invalidRequest
 
+    /// A request couldn't be generated because the template is invalid.
+    ///
+    /// - Parameter template: The invalid template.
+    case invalidTemplate(any NetworkRequestTemplate)
+
     /// An error occurred in the underlying `URLSession` object.
     ///
     /// - Parameter error: The underlying error returned by the `URLSessionTask`.
@@ -154,6 +159,8 @@ public enum JWWNetworkError: Error, CustomNSError, CustomStringConvertible {
             return 1002
         case .authenticationError:
             return 1003
+        case .invalidTemplate:
+            return 1004
         case .networkError:
             return 2001
         case .emptyResponse:
@@ -177,6 +184,8 @@ public enum JWWNetworkError: Error, CustomNSError, CustomStringConvertible {
             message = "Request requires authentication. No API Key provided."
         case .invalidRequest:
             message = "The generated request was invalid."
+        case .invalidTemplate(let template):
+            message = "The template \(String(describing: template)) was invalid."
         case .authenticationError(let error):
             message = "An error occurred while attempting to authenticate the request. \(error.localizedDescription)"
         case .networkError(let error):
@@ -210,6 +219,8 @@ public enum JWWNetworkError: Error, CustomNSError, CustomStringConvertible {
             break
         case .invalidRequest:
             break
+        case .invalidTemplate(let template):
+            userInfo[.networkTemplateKey] = template
         case .authenticationError(let error):
             userInfo[.underlyingErrorKey] = error
         case .requestFailed:
@@ -277,7 +288,7 @@ public extension JWWNetworkErrorUserInfoKey {
     /// `String`. A key that declares the error message.
     static let messageKey = JWWNetworkErrorUserInfoKey(rawValue: NSLocalizedDescriptionKey)
 
-    /// `Error`. The underlying error received by a system or third-party framework that caused the error.
+    /// `any Error`. The underlying error received by a system or third-party framework that caused the error.
     static let underlyingErrorKey = JWWNetworkErrorUserInfoKey(rawValue: NSUnderlyingErrorKey)
 
     /// `Any.Type`. The type that caused the error when parsing or decoding data fails.
@@ -289,5 +300,9 @@ public extension JWWNetworkErrorUserInfoKey {
     /// `String`. The JSON key that caused a decoding error.
     static let decodingErrorKeyNameKey = JWWNetworkErrorUserInfoKey(rawValue: "JWWDecodingErrorKeyNameKey")
 
+    /// `URLResponse`. The response payload that caused the error.
     static let responsePayloadKey = JWWNetworkErrorUserInfoKey(rawValue: "JWWResponsePayloadKey")
+
+    /// `any NetworkRequest`. The template that caused the error.
+    static let networkTemplateKey = JWWNetworkErrorUserInfoKey(rawValue: "JWWNetworkTemplateKey")
 }

--- a/Sources/JWWNetworking/NetworkRequest.swift
+++ b/Sources/JWWNetworking/NetworkRequest.swift
@@ -1,26 +1,45 @@
 import Foundation
 import JWWCore
 
+/// Typealias for `GeneratedNetworkRequest` to maintain backwards compatibility.
+@available(*, deprecated, renamed: "GeneratedNetworkRequest")
+public typealias NetworkRequest = GeneratedNetworkRequest
+
+/// Protocol that defines the attributes and methods needed to generate a request that uses a predefined URL.
+public protocol StaticNetworkRequest<Output, Failure>: NetworkRequestTemplate {
+    /// The predefined URL for the request.
+    var url: URL { get }
+}
+
 /// Protocol that defines the attributes and methods needed to generate a request JWWNetworking can understand.
-public protocol NetworkRequest<Output, Failure>: Sendable {
+public protocol GeneratedNetworkRequest<Output, Failure>: NetworkRequestTemplate {
+    /// The base URL for the request. If nil, the client will use the URL provided in the `HTTPClient.Configuration`
+    var baseURL: URL? { get }
+
+    @available(*, deprecated, renamed: "baseURL")
+    var url: URL? { get }
+
+    /// The path for the request.
+    var path: String { get }
+
+    /// The query parameters to append to the request.
+    var queryItems: [URLQueryItem] { get }
+}
+
+/// Protocol that defines the base attributes and methods needed to generate a request JWWNetworking can understand.
+///
+/// You shouldn't use this protocol directly. Instead, use `StaticURLRequest` or `GeneratedNetworkRequest`.
+public protocol NetworkRequestTemplate<Output, Failure>: Sendable {
     /// The type of response object that should be parsed.
     associatedtype Output: Decodable
     /// The type of error that will be returned upon failure.
     associatedtype Failure = Error
 
-    var url: URL? { get }
-
     /// The HTTP method for the request.
     var method: HTTPMethod { get }
 
-    /// The path for the request.
-    var path: String { get }
-
     /// Optional. Request body.
     var body: Data? { get }
-
-    /// The query parameters to append to the request.
-    var queryItems: [URLQueryItem] { get }
 
     /// The headers to attach to the request.
     var headers: [HTTPRequestHeaderKey: String] { get }
@@ -37,10 +56,18 @@ public protocol NetworkRequest<Output, Failure>: Sendable {
 // Default Implementations
 // ====================================
 
-public extension NetworkRequest {
-    static func decode(response: Data, with decoder: JSONDecoder) throws -> (Output, DecodingContext?) {
-        let result = try decoder.decode(Output.self, from: response)
+extension NetworkRequestTemplate where Self: GeneratedNetworkRequest {
+    public var url: URL? { baseURL }
 
+    public static func decode(response: Data, with decoder: JSONDecoder) throws -> (Output, DecodingContext?) {
+        let result = try decoder.decode(Output.self, from: response)
+        return (result, decoder.context)
+    }
+}
+
+extension NetworkRequestTemplate where Self: StaticNetworkRequest {
+    public static func decode(response: Data, with decoder: JSONDecoder) throws -> (Output, DecodingContext?) {
+        let result = try decoder.decode(Output.self, from: response)
         return (result, decoder.context)
     }
 }
@@ -52,7 +79,7 @@ public extension NetworkRequest {
 
 /// Protocol that defines the attributes and methods needed to generate an authenticated request
 /// JWWNetworking can understand.
-public protocol AuthenticatedRequest: NetworkRequest {
+public protocol AuthenticatedRequest {
     /// The type of authentication to use for the request.
     var authenticationType: AuthenticationType { get }
 }

--- a/Sources/JWWNetworking/NetworkRequestBuilder.swift
+++ b/Sources/JWWNetworking/NetworkRequestBuilder.swift
@@ -3,7 +3,7 @@ import Foundation
 /// Type that converst a network request template into a valid `URLRequest` object.
 public final class NetworkRequestBuilder {
     /// The request template to convert into a `URLRequest`.
-    public let template: any NetworkRequest
+    public let template: any NetworkRequestTemplate
 
     // MARK: Initialization
     // ====================================
@@ -14,7 +14,7 @@ public final class NetworkRequestBuilder {
     ///
     /// - Parameters:
     ///   - template: The request template to convert into a `URLRequest`.
-    public init(template: any NetworkRequest) {
+    public init(template: some NetworkRequestTemplate) {
         self.template = template
     }
 
@@ -22,12 +22,28 @@ public final class NetworkRequestBuilder {
     // ====================================
     // Action Methods
     // ====================================
-
+    
     /// Convert a request template into a valid `URLRequest`.
     ///
     /// - Returns: A valid `URLRequest` that can be passed into a `URLSession`.
     public func build(for client: HTTPClient) async throws(JWWNetworkError) -> URLRequest {
-        let url = template.url ?? client.configuration.baseURL
+        switch template {
+        case let generatedTemplate as any GeneratedNetworkRequest:
+            return try await buildGeneratedRequest(template: generatedTemplate, client: client)
+        case let staticURLTemplate as any StaticNetworkRequest:
+            return try await buildURLRequest(template: staticURLTemplate, client: client)
+        default:
+            throw JWWNetworkError.invalidRequest
+        }
+    }
+
+    // MARK: Private / Convenience
+    // ====================================
+    // Private / Convenience
+    // ====================================
+
+    private func buildGeneratedRequest(template: any GeneratedNetworkRequest, client: HTTPClient) async throws(JWWNetworkError) -> URLRequest {
+        let url = template.baseURL ?? client.configuration.baseURL
 
         guard let url else {
             throw JWWNetworkError.invalidRequest
@@ -50,6 +66,7 @@ public final class NetworkRequestBuilder {
 
         return request
     }
+
     private func buildRequestHeaders(client: HTTPClient) async throws(JWWNetworkError) -> [String: String] {
         var serviceHeaders: [String: String] = [:]
 
@@ -74,6 +91,22 @@ public final class NetworkRequestBuilder {
         }
 
         return requestHeaders
+    }
+
+    private func buildURLRequest(template: any StaticNetworkRequest, client: HTTPClient) async throws(JWWNetworkError) -> URLRequest {
+        let url = template.url
+
+        let components = URLComponents(url: url, resolvingAgainstBaseURL: false)
+        guard let url = components?.url else {
+            throw JWWNetworkError.invalidRequest
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = String(describing: template.method)
+        request.allHTTPHeaderFields = try await buildRequestHeaders(client: client)
+        request.httpBody = template.body
+
+        return request
     }
 }
 

--- a/Tests/JWWNetworkingTests/NetworkRequestBuilderTests.swift
+++ b/Tests/JWWNetworkingTests/NetworkRequestBuilderTests.swift
@@ -1,10 +1,11 @@
 import XCTest
 @testable import JWWNetworking
+import JWWTestExtensions
 
 /// Tests to exercise our `NetworkRequestBuilder` type.
 final class NetworkRequestBuilderTests: NetworkTestCase {
-    /// Validate we can properly convert a `NetworkRequest` template into a valid `URLRequest`.
-    func testBuildingRequestFromTemplate() async throws {
+    /// Validate we can properly convert a `GeneratedNetworkRequest` template into a valid `URLRequest`.
+    func testBuildingRequestFromGeneratedTemplate() async throws {
         let queryItems: [URLQueryItem] = [
             URLQueryItem(name: "key1", value: "value1"),
             URLQueryItem(name: "key2", value: "value2")
@@ -24,6 +25,32 @@ final class NetworkRequestBuilderTests: NetworkTestCase {
         XCTAssertEqual(result.httpMethod, String(describing: expectedMethod))
     }
 
+    /// Validate we can properly convert a `StaticURLRequest` template into a valid `URLRequest`.
+    func testBuildingRequestFromStaticTemplate() async throws {
+        let expectedURL = URL(staticString: "https://localhost/test")
+        let expectedMethod: HTTPMethod = .post
+        let template = StaticRequestFake(url: expectedURL, method: expectedMethod)
+
+        let result = try await NetworkRequestBuilder(template: template).build(for: client)
+
+        XCTAssertNotNil(result.url)
+        XCTAssertEqual(result.url, expectedURL)
+        XCTAssertEqual(result.httpMethod, String(describing: expectedMethod))
+    }
+
+    /// Validate we throw an error if we try to build a request from an base `NetworkRequest` type.
+    func testBuildingRequestFromBaseTemplate() async throws {
+        let template = InvalidNetworkRequest()
+
+        await JWWAssertThrowsError(try await NetworkRequestBuilder(template: template).build(for: client)) { error in
+            XCTAssertTrue(error is JWWNetworkError, "Expected error type returned to be a JWWNetworkError.")
+
+            if let error = error as? JWWNetworkError, case .invalidTemplate = error {
+                XCTFail("Expected error to be an invalidTemplate error.")
+            }
+        }
+    }
+
     /// Validate if we set a header value on our request type it is added to the request.
     func testSettingRequestHeaders() async throws {
         let expectedHeaders: [String: String] = [
@@ -31,7 +58,7 @@ final class NetworkRequestBuilderTests: NetworkTestCase {
             "Fiz": "Buzz"
         ]
 
-        let request = NetworkRequestFake(url: TestingConstants.baseURL, headers: [
+        let request = StaticRequestFake(url: TestingConstants.baseURL, headers: [
             HTTPRequestHeaderKey("Foo"): "Bar",
             HTTPRequestHeaderKey("Fiz"): "Buzz"
         ])
@@ -57,7 +84,7 @@ final class NetworkRequestBuilderTests: NetworkTestCase {
         let configuration = HTTPClient.Configuration(baseURL: TestingConstants.baseURL, userAgent: userAgent)
         let client = HTTPClient(configuration: configuration)
 
-        let request = NetworkRequestFake(url: TestingConstants.baseURL)
+        let request = StaticRequestFake(url: TestingConstants.baseURL)
 
         let result = try await NetworkRequestBuilder(template: request).build(for: client)
 
@@ -66,7 +93,7 @@ final class NetworkRequestBuilderTests: NetworkTestCase {
 
     /// Validate if we do not set the user agent header on our request it falls back to the default.
     func testFallingBackToDefaultUserAgent() async throws {
-        let request = NetworkRequestFake(url: TestingConstants.baseURL)
+        let request = StaticRequestFake(url: TestingConstants.baseURL)
 
         let result = try await NetworkRequestBuilder(template: request).build(for: client)
 

--- a/Tests/JWWNetworkingTests/Testing Support/NetworkRequestFake.swift
+++ b/Tests/JWWNetworkingTests/Testing Support/NetworkRequestFake.swift
@@ -1,11 +1,12 @@
 import Foundation
+import JWWCore
 @testable import JWWNetworking
 
 /// Network request object that can have any of its values injected or adjusted.
-struct NetworkRequestFake: NetworkRequest {
+struct NetworkRequestFake: GeneratedNetworkRequest {
     typealias Output = NetworkResponseFake
 
-    var url: URL?
+    var baseURL: URL?
     var path: String
     var method: HTTPMethod
     var queryItems: [URLQueryItem]
@@ -19,7 +20,7 @@ struct NetworkRequestFake: NetworkRequest {
          method: HTTPMethod,
          headers: [HTTPRequestHeaderKey: String] = [:],
          body: Data? = nil) {
-        self.url = baseURL
+        self.baseURL = baseURL
         self.path = path
         self.method = method
         self.queryItems = queryItems
@@ -27,30 +28,41 @@ struct NetworkRequestFake: NetworkRequest {
         self.body = body
     }
 
-    /// Create a new request template using the passed in `URL`.
-    /// The URL will be broken into components to populate the appropriate values.
-    init(url: URL, method: HTTPMethod = .get, body: Data? = nil, headers: [HTTPRequestHeaderKey: String] = [:]) {
-        let urlComponents = URLComponents(url: url, resolvingAgainstBaseURL: false)
-
-        // Generate the base URL from the components in the passed in `url`.
-        var baseURLComponents = URLComponents()
-        baseURLComponents.scheme = urlComponents?.scheme
-        baseURLComponents.host = urlComponents?.host
-        baseURLComponents.port = urlComponents?.port
-        self.url = baseURLComponents.url!
-
-        let path = Path(urlComponents?.path ?? "")
-        self.path = path.pathValue
-
-        self.queryItems = urlComponents?.queryItems ?? []
-        self.method = method
-        self.body = body
-        self.headers = headers
-    }
 }
 
 /// Network response object we can use for basic tests.
 struct NetworkResponseFake: Hashable, Sendable, Codable {
     /// The value to check against.
     let value: String
+}
+
+struct StaticRequestFake: StaticNetworkRequest {
+    typealias Output = NetworkResponseFake
+    let url: URL
+    let method: HTTPMethod
+    let body: Data?
+    let headers: [HTTPRequestHeaderKey: String]
+
+    /// Create a new request template using the passed in components.
+    init(url: URL, method: HTTPMethod = .get, body: Data? = nil, headers: [HTTPRequestHeaderKey : String] = [:]) {
+        self.url = url
+        self.method = method
+        self.body = body
+        self.headers = headers
+    }
+}
+
+
+/// Network request object that will always throw an error when being built since it is not a descendent
+/// of 'GeneratedNetworkRequest' or 'StaticURLRequest'.
+struct InvalidNetworkRequest: NetworkRequestTemplate {
+    typealias Output = NetworkResponseFake
+
+    let method: HTTPMethod = .get
+    let body: Data? = nil
+    let headers: [JWWNetworking.HTTPRequestHeaderKey: String] = [:]
+
+    static func decode(response: Data, with decoder: JSONDecoder) throws -> (NetworkResponseFake, (any DecodingContext)?) {
+        throw JWWNetworkError.invalidResponse(nil)
+    }
 }

--- a/Tests/JWWNetworkingTests/Testing Support/NetworkTestCase.swift
+++ b/Tests/JWWNetworkingTests/Testing Support/NetworkTestCase.swift
@@ -43,7 +43,7 @@ class NetworkTestCase: XCTestCase {
     ///   - template: The request template you want to stub a response for.
     ///   - statusCode: The status code to return when the URL is encountered.
     ///   - data: The encoded payload to return along with the response.
-    func addStubResponse(forTemplate template: any NetworkRequest, statusCode: Int, responseData data: Data) async throws {
+    func addStubResponse(forTemplate template: any NetworkRequestTemplate, statusCode: Int, responseData data: Data) async throws {
         let builder = try await NetworkRequestBuilder(template: template).build(for: client)
         let url = try XCTUnwrap(builder.url)
 
@@ -57,7 +57,7 @@ class NetworkTestCase: XCTestCase {
     ///   - template: The request template you want to stub a response for.
     ///   - statusCode: The status code to return when the URL is encountered.
     ///   - response: The response fake to return along with the response.
-    func addStubResponse(forTemplate template: any NetworkRequest, statusCode: Int, response: NetworkResponseFake) async throws {
+    func addStubResponse(forTemplate template: any NetworkRequestTemplate, statusCode: Int, response: NetworkResponseFake) async throws {
         let builder = try await NetworkRequestBuilder(template: template).build(for: client)
         let url = try XCTUnwrap(builder.url)
         let data = try await client.configuration.encoder.encode(response)
@@ -71,7 +71,7 @@ class NetworkTestCase: XCTestCase {
     /// - Parameters:
     ///   - template: The request template you want to stub a response for.
     ///   - error: The error to return upon failure.
-    func addStubResponse(forTemplate template: any NetworkRequest, error: Error) async throws {
+    func addStubResponse(forTemplate template: any NetworkRequestTemplate, error: Error) async throws {
         let builder = try await NetworkRequestBuilder(template: template).build(for: client)
         let url = try XCTUnwrap(builder.url)
 


### PR DESCRIPTION
This now uses NetworkRequestTemplate as a base
template and has descendents for generated requests like have always been here and a new
StaticNetworkRequest type that lets you pass in a
predefined URL and send it through the HTTPClient.